### PR TITLE
Engine refactoring

### DIFF
--- a/examples/breakout.cpp
+++ b/examples/breakout.cpp
@@ -5,50 +5,45 @@
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
-static P2DQuadModel paddle_model;
-static P2DQuadEntity paddle;
+static P2DQuadEntity *paddle;
 
-static P2DCircleModel ball_model;
-static P2DCircleEntity ball;
+static P2DEllipseEntity *ball;
 
 void game_init() {
-    Texture t = load_texture("../res/test.png");
+    P2D_init();
 
     // TODO: Here the user should be able to pass the initial window size and
     // additional parameters
 
-    // load shaders
-    // TODO: Maybe the're should be 'default' shaders that get loaded when creating a model,
-    // and the user can specify if they want to use their own shaders.
-    Shader test_vertex_shader = { GL_VERTEX_SHADER, "../src/shaders/test.vert" };
-    Shader test_fragment_shader = { GL_FRAGMENT_SHADER, "../src/shaders/test.frag" };
-    Shader test_shaders[2] = { test_vertex_shader, test_fragment_shader };
-
-    ShaderProgram test_shader_program;
-    if(!create_shader_program(test_shaders, 2, &test_shader_program)) {
-        SDL_LogError(SDL_LOG_CATEGORY_ERROR, "ERROR [Could not create shader program]");
-    }
-
-    glm::mat4 projection = glm::ortho(0.0f, 800.0f, 600.0f, 0.0f, -1.0f, 1.0f);
-
-    glUseProgram(test_shader_program.id);
-    shader_program_load_mat4(test_shader_program.id, "projection", projection);
-    glUseProgram(0);
+    // If we specify the source path for the shaders the engine should use some default shaders
+    Shader test_vertex_shader = { GL_VERTEX_SHADER, NULL };
+    Shader test_fragment_shader = { GL_FRAGMENT_SHADER, NULL };
+    Shader test_default_shaders[2] = { test_vertex_shader, test_fragment_shader };
 
     // Paddle
-    paddle_model = p2d_quad_model_new(64, 32);
-
+    float paddle_width = 64;
+    float paddle_height = 32;
     Vector2 paddle_position; 
-    paddle_position.x = (800.0f / 2.0f) - (paddle_model.width / 2.0f);
-    paddle_position.y = (600.0f - paddle_model.height - 16.0f);
-    paddle = p2d_quad_entity_new(paddle_position, paddle_position, &paddle_model, test_shader_program.id);
+    paddle_position.x = (800.0f / 2.0f) - (paddle_width / 2.0f);
+    paddle_position.y = (600.0f - paddle_height - 16.0f);
+    paddle = p2d_quad_entity_new(paddle_position, paddle_position, paddle_width, paddle_height, test_default_shaders);
+    if(!paddle) {
+        // TODO: error handling
+    }
 
     // Ball 
     // TODO: Maybe the ball should be a quad as well, since we're going to use sprites anyway 
-    ball_model = p2d_circle_model_new(16.0f, 16.0f);
-
-    Vector2 ball_position = { (800.0f / 2.0f), (600.0f / 2.0f) - (ball_model.height / 2.0f) };
-    ball = p2d_circle_entity_new(ball_position, ball_position, &ball_model, test_shader_program.id);
+    test_default_shaders[0].src_path = NULL;
+    test_default_shaders[1].src_path = NULL;
+    float ball_height = 32;
+    Vector2 ball_position = { (800.0f / 2.0f), (600.0f / 2.0f) - (ball_height / 2.0f) };
+    ball = p2d_ellipse_entity_new(ball_position, ball_position, 16, 16, test_default_shaders);
+    if(!ball) {
+        // TODO: error handling
+    } else {
+        ball->velocity.x = 2.0f;
+        ball->velocity.y = 2.0f;
+    }
 }
 
 void game_update(KeyboardState *keyboard_state) {
@@ -66,45 +61,45 @@ void game_update(KeyboardState *keyboard_state) {
     // }
 
     // Paddle movement
-    paddle.position.x += paddle.velocity.x;
-    paddle.position.y += paddle.velocity.y;
+    paddle->position.x += paddle->velocity.x;
+    paddle->position.y += paddle->velocity.y;
 
-    paddle.velocity.x = 0.0f;
-    paddle.velocity.y = 0.0f;
+    paddle->velocity.x = 0.0f;
+    paddle->velocity.y = 0.0f;
 
     float speed = 20.0f;
     if(key_is_down(keyboard_state->keys[KEY_A])) {
-        paddle.velocity.x -= speed;
+        paddle->velocity.x -= speed;
     }
 
     if(key_is_down(keyboard_state->keys[KEY_D])) {
-        paddle.velocity.x += speed;
+        paddle->velocity.x += speed;
     }
 
     if(key_is_down(keyboard_state->keys[KEY_S])) {
-        paddle.velocity.y += speed;
+        paddle->velocity.y += speed;
     }
 
     if(key_is_down(keyboard_state->keys[KEY_W])) {
-        paddle.velocity.y -= speed;
+        paddle->velocity.y -= speed;
     }
 
     // Ball movement
-    ball.position.x += ball.velocity.x;
-    ball.position.y += ball.velocity.y;
+    ball->position.x += ball->velocity.x;
+    ball->position.y += ball->velocity.y;
 
-    if(((ball.position.y + ball.model->height) >= 600.0f) || 
-            ((ball.position.y - ball.model->height) < 0.0f)) {
-        ball.velocity.y = -ball.velocity.y;
+    if(((ball->position.y + ball->height) >= 600.0f) || 
+            ((ball->position.y - ball->height) < 0.0f)) {
+        ball->velocity.y = -ball->velocity.y;
     }
 
-    if(((ball.position.x + ball.model->width) >= 800.0f) ||
-            ((ball.position.x - ball.model->width) <= 0.0f)) {
-        ball.velocity.x = -ball.velocity.x;
+    if(((ball->position.x + ball->width) >= 800.0f) ||
+            ((ball->position.x - ball->width) <= 0.0f)) {
+        ball->velocity.x = -ball->velocity.x;
     }
 }
 
 void game_render(float dt) {
-    p2d_quad_render(&paddle, dt);
-    p2d_circle_render(&ball, dt);
+    p2d_quad_render(paddle, dt);
+    p2d_ellipse_render(ball, dt);
 }

--- a/src/build.bat
+++ b/src/build.bat
@@ -11,7 +11,7 @@ set COMPILER_OPTIONS=/external:W4 /external:I%SDL_HEADERS_PATH% /W4 /Zi
 set LINKER_OPTIONS=/LIBPATH:%SDL_LIBRARY_PATH% /subsystem:windows 
 
 set FILE_PATH="..\src"
-set FILES=%FILE_PATH%\platform.cpp %FILE_PATH%\glad.c %FILE_PATH%\shader_program.cpp %FILE_PATH%\engine.cpp %FILE_PATH%\texture.cpp
+set FILES=%FILE_PATH%\platform.cpp %FILE_PATH%\glad.c %FILE_PATH%\shader_program.cpp %FILE_PATH%\engine.cpp %FILE_PATH%\texture.cpp %FILE_PATH%\gl_util.cpp
 
 
 IF NOT EXIST ..\build mkdir ..\build

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,71 +1,102 @@
 #include "includes/engine.h"
 #include "includes/shader_program.h"
+#include "includes/gl_util.h"
 
 #include <glm/vec3.hpp>
 #include <glm/mat4x4.hpp>
 #include <glm/matrix.hpp>
 #include <glm/ext/matrix_transform.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+
+static float PI = 3.14159265359f;
+
+#define P2D_MAX_QUAD_ENTITIES 256
+static P2DQuadModel p2d_g_quad_model;
+static P2DQuadEntity p2d_g_quad_entities[P2D_MAX_QUAD_ENTITIES] = {};
+static uint8_t p2d_g_active_quad_entities[P2D_MAX_QUAD_ENTITIES] = {};
+
+#define P2D_MAX_ELLIPSE_ENTITIES 256
+static P2DEllipseModel p2d_g_ellipse_model;
+static P2DEllipseEntity p2d_g_ellipse_entities[P2D_MAX_ELLIPSE_ENTITIES] = {};
+static uint8_t p2d_g_active_ellipse_entities[P2D_MAX_ELLIPSE_ENTITIES] = {};
 
 // TODO: load textures
-P2DQuadModel p2d_quad_model_new(uint32_t width, uint32_t height) {
-    P2DQuadModel model = {};
+void p2d_quad_model_init() {
+    p2d_g_quad_model.vertices[0].pos.x = 0.0f;
+    p2d_g_quad_model.vertices[0].pos.y = 1.0f;
 
-    model.vertices[0].pos.x = 0.0f;
-    model.vertices[0].pos.y = 1.0f;
+    p2d_g_quad_model.vertices[1].pos.x = 1.0f;
+    p2d_g_quad_model.vertices[1].pos.y = 1.0f;
 
-    model.vertices[1].pos.x = 1.0f;
-    model.vertices[1].pos.y = 1.0f;
+    p2d_g_quad_model.vertices[2].pos.x = 1.0f;
+    p2d_g_quad_model.vertices[2].pos.y = 0.0f;
 
-    model.vertices[2].pos.x = 1.0f;
-    model.vertices[2].pos.y = 0.0f;
+    p2d_g_quad_model.vertices[3].pos.x = 0.0f;
+    p2d_g_quad_model.vertices[3].pos.y = 0.0f;
 
-    model.vertices[3].pos.x = 0.0f;
-    model.vertices[3].pos.y = 0.0f;
+    p2d_g_quad_model.vertices[4].pos.x = 0.0f;
+    p2d_g_quad_model.vertices[4].pos.y = 1.0f;
 
-    model.vertices[4].pos.x = 0.0f;
-    model.vertices[4].pos.y = 1.0f;
+    p2d_g_quad_model.vertices[5].pos.x = 1.0f;
+    p2d_g_quad_model.vertices[5].pos.y = 0.0f;
 
-    model.vertices[5].pos.x = 1.0f;
-    model.vertices[5].pos.y = 0.0f;
-
-    model.width = width;
-    model.height = height;
-
-    GLuint vao;
-    glGenVertexArrays(1, &vao);
-    glBindVertexArray(vao);
-
-    GLuint vbo;
-    glGenBuffers(1, &vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    
-    glBufferData(GL_ARRAY_BUFFER, sizeof(model.vertices), model.vertices, GL_STATIC_DRAW);
-
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0); // position
-
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float))); // texture coords
-
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    model.vao = vao;
-    model.vbo = vbo;
-
-    return model;
+    load_gl_buffers(p2d_g_quad_model.vertices, 6, &p2d_g_quad_model.vbo, &p2d_g_quad_model.vao);
 }
 
-P2DQuadEntity p2d_quad_entity_new(Vector2 position, Vector2 rotation, P2DQuadModel *model, GLuint shader_program_id) {
-    P2DQuadEntity entity = {};
+int p2d_load_entity_shaders(ShaderProgram *shader_program, Shader shaders[2]) {
+    // If user did not specify their own shaders, we just load some default ones
+    if(!shaders[0].src_path) {
+        shaders[0].src_path = "../src/shaders/test.vert";
+        // TODO: Maybe the path should be reset to NULL before returning
+    }
 
-    entity.position.x = position.x;
-    entity.position.y = position.y;
-    entity.rotation.x = rotation.x;
-    entity.rotation.y = rotation.y;
-    entity.model = model;
-    entity.shader_program.id = shader_program_id;
-    
+    if(!shaders[1].src_path) {
+        shaders[1].src_path = "../src/shaders/test.frag";
+        // TODO: Maybe the path should be reset to NULL before returning
+    }
+
+    if(!create_shader_program(shaders, 2, shader_program)) {
+        // TODO: error handling
+        SDL_LogError(SDL_LOG_CATEGORY_ERROR, "ERROR [Could not create shader program]");
+
+        return 0;
+    }
+    glm::mat4 projection = glm::ortho(0.0f, 800.0f, 600.0f, 0.0f, -1.0f, 1.0f);
+    glUseProgram(shader_program->id);
+    shader_program_load_mat4(shader_program->id, "projection", projection);
+    glUseProgram(0);
+}
+
+P2DQuadEntity *p2d_quad_entity_new(Vector2 position, Vector2 rotation, uint32_t width, uint32_t height, Shader shaders[2]) {
+    uint8_t entity_id = 0;
+    // Find available entity
+    while(p2d_g_active_quad_entities[entity_id] && (entity_id < P2D_MAX_QUAD_ENTITIES)) {
+        entity_id++;
+    }
+
+    if(entity_id == P2D_MAX_QUAD_ENTITIES) {
+        // TODO: error handling
+        printf("No quad entities available\n");
+
+        return NULL;
+    }
+    p2d_g_active_quad_entities[entity_id] = 1;
+
+    P2DQuadEntity *entity = (p2d_g_quad_entities + entity_id);
+    if(!p2d_load_entity_shaders(&entity->shader_program, shaders)) {
+        // TODO: error handling
+
+        return NULL;
+    }
+
+    entity->position.x = position.x;
+    entity->position.y = position.y;
+    entity->rotation.x = rotation.x;
+    entity->rotation.y = rotation.y;
+    entity->width = width;
+    entity->height = height;
+    entity->model = &p2d_g_quad_model;
+
     return entity;
 }
 
@@ -77,7 +108,7 @@ void p2d_quad_render(P2DQuadEntity *quad, float dt) {
     float pos_y = quad->position.y + (quad->velocity.y * dt);
 
     model = glm::translate(model, glm::vec3(pos_x, pos_y, 1.0f));
-    model = glm::scale(model, glm::vec3(quad->model->width, quad->model->height, 1.0f));
+    model = glm::scale(model, glm::vec3(quad->width, quad->height, 1.0f));
 
     shader_program_load_mat4(quad->shader_program.id, "model", model);
 
@@ -89,105 +120,95 @@ void p2d_quad_render(P2DQuadEntity *quad, float dt) {
     glBindVertexArray(0);
 }
 
-P2DCircleModel p2d_circle_model_new(uint32_t width, uint32_t height) {
-    P2DCircleModel model = {};
-
-    float PI = 3.14159265359;
+void p2d_ellipse_model_init() {
     float pos_x_45 = cos(PI / 4.0f); 
     float pos_y_45 = sin(PI / 4.0f); 
 
     // Center
-    model.vertices[0].pos.x = 0.0f;
-    model.vertices[0].pos.y = 0.0f;
+    p2d_g_ellipse_model.vertices[0].pos.x = 0.0f;
+    p2d_g_ellipse_model.vertices[0].pos.y = 0.0f;
 
     // Top
-    model.vertices[1].pos.x = 0.0f;
-    model.vertices[1].pos.y = 1.0f;
+    p2d_g_ellipse_model.vertices[1].pos.x = 0.0f;
+    p2d_g_ellipse_model.vertices[1].pos.y = 1.0f;
 
-    model.vertices[2].pos.x = pos_x_45;
-    model.vertices[2].pos.y = pos_y_45;
+    p2d_g_ellipse_model.vertices[2].pos.x = pos_x_45;
+    p2d_g_ellipse_model.vertices[2].pos.y = pos_y_45;
 
     // Right
-    model.vertices[3].pos.x = 1.0f;
-    model.vertices[3].pos.y = 0.0f;
+    p2d_g_ellipse_model.vertices[3].pos.x = 1.0f;
+    p2d_g_ellipse_model.vertices[3].pos.y = 0.0f;
 
-    model.vertices[4].pos.x = pos_x_45;
-    model.vertices[4].pos.y = -pos_y_45;
+    p2d_g_ellipse_model.vertices[4].pos.x = pos_x_45;
+    p2d_g_ellipse_model.vertices[4].pos.y = -pos_y_45;
 
     // Bottom
-    model.vertices[5].pos.x = 0.0f;
-    model.vertices[5].pos.y = -1.0f;
+    p2d_g_ellipse_model.vertices[5].pos.x = 0.0f;
+    p2d_g_ellipse_model.vertices[5].pos.y = -1.0f;
 
-    model.vertices[6].pos.x = -pos_x_45;
-    model.vertices[6].pos.y = -pos_y_45;
+    p2d_g_ellipse_model.vertices[6].pos.x = -pos_x_45;
+    p2d_g_ellipse_model.vertices[6].pos.y = -pos_y_45;
 
     // Left
-    model.vertices[7].pos.x = -1.0f;
-    model.vertices[7].pos.y = 0.0f;
+    p2d_g_ellipse_model.vertices[7].pos.x = -1.0f;
+    p2d_g_ellipse_model.vertices[7].pos.y = 0.0f;
 
-    model.vertices[8].pos.x = -pos_x_45;
-    model.vertices[8].pos.y = pos_y_45;
+    p2d_g_ellipse_model.vertices[8].pos.x = -pos_x_45;
+    p2d_g_ellipse_model.vertices[8].pos.y = pos_y_45;
 
     // Top
-    model.vertices[9].pos.x = 0.0f;
-    model.vertices[9].pos.y = 1.0f;
+    p2d_g_ellipse_model.vertices[9].pos.x = 0.0f;
+    p2d_g_ellipse_model.vertices[9].pos.y = 1.0f;
 
-    model.width = width;
-    model.height = height;
-
-    GLuint vao;
-    glGenVertexArrays(1, &vao);
-    glBindVertexArray(vao);
-
-    GLuint vbo;
-    glGenBuffers(1, &vbo);
-    glBindBuffer(GL_ARRAY_BUFFER, vbo);
-    
-    glBufferData(GL_ARRAY_BUFFER, sizeof(model.vertices), model.vertices, GL_STATIC_DRAW);
-
-    glEnableVertexAttribArray(0);
-    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0); // position
-
-    glEnableVertexAttribArray(1);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float))); // texture coords
-
-    glBindVertexArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    model.vao = vao;
-    model.vbo = vbo;
-
-    return model;
+    load_gl_buffers(p2d_g_ellipse_model.vertices, 10, &p2d_g_ellipse_model.vbo, &p2d_g_ellipse_model.vao);
 }
 
-P2DCircleEntity p2d_circle_entity_new(Vector2 position, Vector2 rotation, P2DCircleModel *model, GLuint shader_program_id) {
-    P2DCircleEntity entity = {};
+P2DEllipseEntity *p2d_ellipse_entity_new(Vector2 position, Vector2 rotation, uint32_t width, uint32_t height, Shader shaders[2]) {
+    uint8_t entity_id = 0;
+    // Find available entity
+    while(p2d_g_active_ellipse_entities[entity_id] && (entity_id < P2D_MAX_ELLIPSE_ENTITIES)) {
+        entity_id++;
+    }
 
-    entity.position.x = position.x;
-    entity.position.y = position.y;
-    entity.rotation.x = rotation.x;
-    entity.rotation.y = rotation.y;
-    entity.velocity.x = 2.0f;
-    entity.velocity.y = 5.0f;
-    entity.model = model;
-    entity.shader_program.id = shader_program_id;
-    
+    if(entity_id == P2D_MAX_ELLIPSE_ENTITIES) {
+        // TODO: error handling
+        printf("No ellipse entities available\n");
+
+        return NULL;
+    }
+    p2d_g_active_ellipse_entities[entity_id] = 1;
+
+    P2DEllipseEntity *entity = (p2d_g_ellipse_entities + entity_id);
+    if(!p2d_load_entity_shaders(&entity->shader_program, shaders)) {
+        // TODO: error handling
+
+        return NULL;
+    }
+
+    entity->position.x = position.x;
+    entity->position.y = position.y;
+    entity->rotation.x = rotation.x;
+    entity->rotation.y = rotation.y;
+    entity->width = width;
+    entity->height = height;
+    entity->model = &p2d_g_ellipse_model;
+
     return entity;
 }
 
-void p2d_circle_render(P2DCircleEntity *circle, float dt) {
-    glUseProgram(circle->shader_program.id);
+void p2d_ellipse_render(P2DEllipseEntity *ellipse, float dt) {
+    glUseProgram(ellipse->shader_program.id);
     glm::mat4 model = glm::mat4(1.0f);
 
-    float pos_x = circle->position.x + (circle->velocity.x * dt);
-    float pos_y = circle->position.y + (circle->velocity.y * dt);
+    float pos_x = ellipse->position.x + (ellipse->velocity.x * dt);
+    float pos_y = ellipse->position.y + (ellipse->velocity.y * dt);
 
     model = glm::translate(model, glm::vec3(pos_x, pos_y, 1.0f));
-    model = glm::scale(model, glm::vec3(circle->model->width, circle->model->height, 1.0f));
+    model = glm::scale(model, glm::vec3(ellipse->width, ellipse->height, 1.0f));
 
-    shader_program_load_mat4(circle->shader_program.id, "model", model);
+    shader_program_load_mat4(ellipse->shader_program.id, "model", model);
 
-    glBindVertexArray(circle->model->vao);
+    glBindVertexArray(ellipse->model->vao);
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, 10);
 
@@ -210,4 +231,9 @@ bool key_released_this_frame(KeyboardKey key) {
 
 bool key_is_down(KeyboardKey key) {
     return key.is_down;
+}
+
+void P2D_init() {
+    p2d_quad_model_init();
+    p2d_ellipse_model_init();
 }

--- a/src/gl_util.cpp
+++ b/src/gl_util.cpp
@@ -1,0 +1,20 @@
+#include "includes/gl_util.h"
+
+void load_gl_buffers(Vertex *vertices, uint64_t n, GLuint *vbo, GLuint *vao) {
+    glGenVertexArrays(1, vao);
+    glBindVertexArray(*vao);
+
+    glGenBuffers(1, vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, *vbo);
+    
+    glBufferData(GL_ARRAY_BUFFER, sizeof(*vertices) * n, vertices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0); // position
+
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)(2 * sizeof(float))); // texture coords
+
+    glBindVertexArray(0);
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+}

--- a/src/includes/engine.h
+++ b/src/includes/engine.h
@@ -5,58 +5,47 @@
 #include "includes/sdl_gl.h"
 
 #include "includes/shader_program.h"
+#include "includes/vertex.h"
 
-struct Vector2 {
-    float x;
-    float y;
-};
-
-struct Vertex {
-    Vector2 pos; // TODO: replace with glm::vec2?
-    Vector2 tex;
-}; 
+void P2D_init();
 
 struct P2DQuadModel {
     Vertex vertices[6];
-    uint32_t width; // TODO: If we move out width & height from the model we would only need 1 instance of this struct
-    uint32_t height;
     GLuint vao;
     GLuint vbo;
 };
-
-struct P2DQuadModel p2d_quad_model_new(uint32_t width, uint32_t height);
 
 struct P2DQuadEntity {
     P2DQuadModel *model;
     Vector2 position; // TODO: replace with glm::vec2?
     Vector2 velocity;
     Vector2 rotation;
+    uint32_t width; 
+    uint32_t height;
     ShaderProgram shader_program;
 };
 
-P2DQuadEntity p2d_quad_entity_new(Vector2 position, Vector2 rotation, P2DQuadModel *model, GLuint shader_program_id); 
+P2DQuadEntity *p2d_quad_entity_new(Vector2 position, Vector2 rotation, uint32_t width, uint32_t height, Shader shaders[2]);
 void p2d_quad_render(P2DQuadEntity *quad, float dt);
 
-struct P2DCircleModel {
+struct P2DEllipseModel {
     Vertex vertices[10];
-    uint32_t width; // TODO: If we move out width & height from the model we would only need 1 instance of this struct
-    uint32_t height;
     GLuint vao;
     GLuint vbo;
 };
 
-P2DCircleModel p2d_circle_model_new(uint32_t width, uint32_t height);
-
-struct P2DCircleEntity {
-    P2DCircleModel *model;
+struct P2DEllipseEntity {
+    P2DEllipseModel *model;
     Vector2 position; // TODO: replace with glm::vec2?
     Vector2 velocity;
     Vector2 rotation;
+    uint32_t width; 
+    uint32_t height;
     ShaderProgram shader_program;
 };
 
-P2DCircleEntity p2d_circle_entity_new(Vector2 position, Vector2 rotation, P2DCircleModel *model, GLuint shader_program_id); 
-void p2d_circle_render(P2DCircleEntity *circle, float dt);
+P2DEllipseEntity *p2d_ellipse_entity_new(Vector2 position, Vector2 rotation, uint32_t width, uint32_t height, Shader shaders[2]);
+void p2d_ellipse_render(P2DEllipseEntity *ellipse, float dt);
 
 enum KeyboardKeyID {
     KEY_W,

--- a/src/includes/gl_util.h
+++ b/src/includes/gl_util.h
@@ -1,0 +1,12 @@
+#ifndef GL_UTIL
+#define GL_UTIL
+
+#include "includes/glad_i.h"
+#include "includes/sdl_gl.h"
+
+#include "includes/vertex.h"
+
+// TODO: rename?
+void load_gl_buffers(Vertex *vertices, uint64_t n, GLuint *vbo, GLuint *vao);
+
+#endif

--- a/src/includes/vertex.h
+++ b/src/includes/vertex.h
@@ -1,0 +1,14 @@
+#ifndef P2D_VERTEX_H
+#define P2D_VERTEX_H
+
+struct Vector2 {
+    float x;
+    float y;
+};
+
+struct Vertex {
+    Vector2 pos; // TODO: replace with glm::vec2?
+    Vector2 tex;
+}; 
+
+#endif


### PR DESCRIPTION
- Statically allocate entities (user could maybe define the max amt. of entities with #define macros in their file.

- Entities of the same type use the same model

- User does not need to pass in their own shaders, the engine will use default ones if the user does provide any.